### PR TITLE
Add Initial CODEOWNERS File

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @BattlesnakeOfficial/community-moderators

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @BattlesnakeOfficial/community-moderators
+* @BattlesnakeOfficial/community-moderators @DaBultz


### PR DESCRIPTION
Add a CODEOWNERS file to help facilitate review of PRs

Currently it has the `community-moderators` Team as the default
CODEOWNERS for the entire repo, plus some other members from
Discord who wanted to be included.

This will likely change as the Docs site expands