### PR TITLE
Fix admonitions under guides

### DIFF
--- a/docs/guides/playing-battlesnake/battlegrounds.md
+++ b/docs/guides/playing-battlesnake/battlegrounds.md
@@ -13,8 +13,8 @@ Each day, between a set time period, Ladders will run up to 100 matches.&#x20;
 
 At the end of each month, the ladders will be scored and achievements awarded based on your placement on the leaderboards (such as 1st, Top 10 or Top 50).
 
-:::caption
-You must first **complete the** [**Training Program**](https://play.battlesnake.com/challenges/) **** before being able to enter your snakes in the Battlegrounds.&#x20;
+:::info
+You must first **complete the** [**Training Program**](https://play.battlesnake.com/challenges/) before being able to enter your snakes in the Battlegrounds.&#x20;
 :::
 
 ## Monthly Changes

--- a/docs/guides/playing-battlesnake/leagues.md
+++ b/docs/guides/playing-battlesnake/leagues.md
@@ -22,7 +22,7 @@ Each league has a Registration, Qualifying, and Tournaments (which consist of tw
 
 When a League is announced, the registration phase opens where participants can register for the League. At this time, the league's game mode and rules will be announced.&#x20;
 
-::success
+:::success
 If this is your first time creating a Battlesnake, check out the [Quickstart Coding Guide](quickstart).
 :::
 


### PR DESCRIPTION
This PR fixes 2 admonitions under guides which did not show properly. Wasn't sure which admonition to use for the `battlegrounds` one, went with the `info`.