### PR TITLE
Adding PowerShell Starter Project

### DIFF
--- a/docs/starter-projects.mdx
+++ b/docs/starter-projects.mdx
@@ -116,6 +116,12 @@ export const communityProjects = [
     authorHref: 'https://github.com/Nettogrof'
   },
   {
+    name: 'PowerShell Starter Project with Azure Functions',
+    href: 'https://github.com/hestan-net/starter-snake-powershell',
+    author: 'Hestan',
+    authorHref: 'https://github.com/hestan-net'
+  },
+  {
     name: 'Node-RED Low-Code Starter Project',
     href: 'https://flows.nodered.org/flow/6cbf34b31e1890bb7a638005bcc4f54b',
     author: 'Sam Machin',


### PR DESCRIPTION
Adding PowerShell starter project to community starter projects.

I noticed it had dropped off the list of community starter projects.

Previously added on what is now old-docs [https://github.com/BattlesnakeOfficial/docs-old/pull/33](https://github.com/BattlesnakeOfficial/docs-old/pull/33).
Not sure if it was unlucky timing with the move to new doc or if it has been purposely removed.