### PR TITLE
Fix the broken "Edit this page" links.

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -39,7 +39,7 @@ const config = {
           // Please change this to your repo.
           // Remove this to remove the "edit this page" links.
           editUrl:
-            'https://github.com/BattlesnakeOfficial/docs',
+            'https://github.com/BattlesnakeOfficial/docs/tree/main',
         },
         blog: false,
         theme: {

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -39,7 +39,7 @@ const config = {
           // Please change this to your repo.
           // Remove this to remove the "edit this page" links.
           editUrl:
-            'https://github.com/BattlesnakeOfficial/docs/tree/main',
+            'https://github.com/BattlesnakeOfficial/docs/edit/main',
         },
         blog: false,
         theme: {


### PR DESCRIPTION
Previously they wouldn't actually point to the right link due to the omission of "/tree/main" in the editUrl.