### PR TITLE
Fixing "Choosing a Head and Tail"

### DIFF
--- a/docs/guides/customizations.md
+++ b/docs/guides/customizations.md
@@ -41,7 +41,7 @@ You can use an [HTML Color Picker Tool](https://www.w3schools.com/colors/colors\
 
 Several customization options are available for how your Battlesnake's head and tail will display on the game board. You can mix and match them however you like.
 
-Just like [choosing a color](#choosing-a-color), your head and tail are provided in response to the [GET /](api/requests/info.md) command of the [Battlesnake API](api/index.md). Each value is a string, matching one of the available options shown [here](https://play.battlesnake.com/customizations/).
+Just like [choosing a color](#choosing-a-color), your head and tail are provided in response to the [GET /](api/requests/info.md) command of the [Battlesnake API](api/index.md). Each value is a string, matching one of the available options shown [on our customizations page](https://play.battlesnake.com/customizations/).
 
 If an invalid value is returned (or no value at all) the `default` options will be displayed.
 

--- a/docs/guides/customizations.md
+++ b/docs/guides/customizations.md
@@ -41,7 +41,7 @@ You can use an [HTML Color Picker Tool](https://www.w3schools.com/colors/colors\
 
 Several customization options are available for how your Battlesnake's head and tail will display on the game board. You can mix and match them however you like.
 
-Just like [choosing a color](#choosing-a-color), your head and tail are provided in response to the [GET /](api/requests/info.md) command of the [Battlesnake API](api/index.md). Each value is a string, matching one of the available options shown below.
+Just like [choosing a color](#choosing-a-color), your head and tail are provided in response to the [GET /](api/requests/info.md) command of the [Battlesnake API](api/index.md). Each value is a string, matching one of the available options shown [here](https://play.battlesnake.com/customizations/).
 
 If an invalid value is returned (or no value at all) the `default` options will be displayed.
 


### PR DESCRIPTION
Changed "shown below" to "shown here" with a link to the customizations page. I don't think just the free options should be shown, users should be able to go straight to the customizations page and see what they've unlocked instead.

Resolves #23 