### PR TITLE
add Elixir starter snake with Fly.io

### DIFF
--- a/docs/starter-projects.md
+++ b/docs/starter-projects.md
@@ -167,6 +167,12 @@ export const communityProjects = [
     href: 'https://github.com/tyrelh/starter-snake-typescript-deno',
     author: 'Tyrel Hiebert',
     authorHref: 'https://github.com/tyrelh'
+  },
+  {
+    name: 'Elixir Snake with Fly.io',
+    href: 'https://github.com/sockbot/elixir-starter-battlesnake',
+    author: 'Andy Chan',
+    authorHref: 'https://github.com/sockbot'
   }
 ]
 


### PR DESCRIPTION
This PR adds an Elixir starter snake with config to deploy to Fly.io as a community starter snake.