### PR TITLE
Fix a few broken links in banner and footer

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -91,7 +91,7 @@ const config = {
       },
       announcementBar: {
         id: 'announcement-bar-4',  // Increment on new announcement
-        content: '⭐️ Whats New at Battlesnake in 2023? <a href="https://blog.battlesnake.com/whats-new-at-battlesnake-in-2023/" target="_blank" rel="noopener noreferrer">Find out here.</a> 💜',
+        content: '⭐️ Whats New at Battlesnake in 2023? <a href="/blog/2023/01/16/whats-new-at-battlesnake-in-2023" target="_blank" rel="noopener noreferrer">Find out here.</a> 💜',
         backgroundColor: '#3e338f',
         textColor: '#ffffff',
         isCloseable: true
@@ -180,7 +180,7 @@ const config = {
             items: [
               {
                 label: 'Guides',
-                to: 'guides'
+                to: '/'
               },
 
               {
@@ -216,7 +216,7 @@ const config = {
             items: [
               {
                 label: 'Blog',
-                href: 'https://blog.battlesnake.com',
+                to: 'blog',
               },
               {
                 label: 'Our Mission',


### PR DESCRIPTION
"[What's new at Battlesnake in 2023?](https://docs.battlesnake.com/blog/2023/01/16/whats-new-at-battlesnake-in-2023)" is such an important post considering the amount of changes but the link in the banner was still pointing to the old Ghost blog post and therefore broken.

I wasn't sure whether there was a better destination for the 'Guides' link as there is no Guides "index" page (maybe there should be one?). The closes page to the guides listing is the root index page so I set it to that. Happy to oblige if another path is more preferred.