### PR TITLE
Add starter-snake-haskell starter project

### DIFF
--- a/docs/starter-projects.md
+++ b/docs/starter-projects.md
@@ -67,6 +67,12 @@ export const communityProjects = [
     authorHref: 'https://github.com/olivercoad'
   },
   {
+    name: 'Haskell Starter with Heroku',
+    href: 'https://github.com/ccntrq/starter-snake-haskell',
+    author: 'Alexander Pankoff',
+    authorHref: 'https://github.com/ccntrq'
+  },
+  {
     name: 'Java Starter Project',
     href: 'https://github.com/battlesnakeofficial/starter-snake-java',
     author: 'BattlesnakeOfficial',


### PR DESCRIPTION
This PR adds a Haskell starter snake with instructions on how to deploy to heroku.