### PR TITLE
fix broken internal links

### DIFF
--- a/docs/guides/00-customizations.md
+++ b/docs/guides/00-customizations.md
@@ -7,7 +7,7 @@ description: Options for customizing your Battlesnake's appearance
 
 You can customize your Battlesnake's appearance in three ways, by choosing a head, tail, and a color to represent your Battlesnake on the game board.
 
-Your choices are determined by how your Battlesnake responds to [Battlesnake API](api) requests &mdash; specifically the root URL.
+Your choices are determined by how your Battlesnake responds to [Battlesnake API](/api) requests &mdash; specifically the root URL.
 
 
 ## Heads and Tails

--- a/docs/guides/02-tournaments.md
+++ b/docs/guides/02-tournaments.md
@@ -24,6 +24,6 @@ That depends highly on the number of developers participating, and how long they
 
 #### How do tournament events usually work?
 
-Most groups find it easiest to use the [Standard 11x11 Map](maps/standard), with 4 Battlesnakes per match. This is plenty challenging for folks who are building Battlesnakes for the first time.
+Most groups find it easiest to use the [Standard 11x11 Map](/maps/standard), with 4 Battlesnakes per match. This is plenty challenging for folks who are building Battlesnakes for the first time.
 
 We recommend at least one full day of Battlesnake development prior to the tournament. Student groups tend to run a tournament over the course of a weekend, similar to a hackathon. Competitions among colleagues tend to happen over a week or so, where developers work on their Battlesnakes throughout the week and then gather on Friday to watch one final tournament.

--- a/docs/guides/04-competitive-play.md
+++ b/docs/guides/04-competitive-play.md
@@ -32,7 +32,7 @@ The amount of time you have to respond is provided in each API request sent. In 
 
 For most Battlesnake developers this won't be a problem. However top competitors will optimize their Battlesnakes to use as much compute time as possible.
 
-If you're experiencing additional latency based on where your Battlesnake is hosted geographically (i.e. far from the game engine servers), check out alternative [Engine Regions](guides/engine-regions) and consider deploying your Battlesnake closer to the game engine.
+If you're experiencing additional latency based on where your Battlesnake is hosted geographically (i.e. far from the game engine servers), check out alternative [Engine Regions](/guides/engine-regions) and consider deploying your Battlesnake closer to the game engine.
 
 
 ## Testing Your Battlesnake Locally

--- a/docs/maps/01-standard.md
+++ b/docs/maps/01-standard.md
@@ -4,7 +4,7 @@ title: 'Standard'
 
 # Map: Standard
 
-This map features Battlesnake in its original form, following the [core game rules](rules) without modification or special cases.
+This map features Battlesnake in its original form, following the [core game rules](/rules) without modification or special cases.
 
 Note that within a Standard Game the number of Battlesnake in the game can vary, and winning strategies for 1v1 games can be different than strategies for four or eight Battlesnakes.
 

--- a/docs/maps/02-royale.md
+++ b/docs/maps/02-royale.md
@@ -4,11 +4,11 @@ title: 'Royale'
 
 # Map: Royale
 
-The Battlesnake Royale map was the first to introduce a new danger, called [Hazards](rules#hazards).
+The Battlesnake Royale map was the first to introduce a new danger, called [Hazards](/rules#hazards).
 
 Hazards slowly encroach from the edges of the game board every 25 turns, creating an ever-shrinking 'safe zone'. Entering a grid location marked as a Hazard will cost 14 health, _in addition_ to the loss of 1 health per turn.
 
-Hazard locations are available in the [Board Object](api/objects/board) of the [Battlesnake API](api), listed under `hazards`.
+Hazard locations are available in the [Board Object](/api/objects/board) of the [Battlesnake API](/api), listed under `hazards`.
 
 Food can spawn inside and outside of the Hazard area. If a Battlesnake consumes food inside a Hazard location, it will receive the full benefits of the food and not be penalized for entering the Hazard.
 


### PR DESCRIPTION
Fix some broken links on maps and guides pages that resulted from a reorg of the docs into different directories.